### PR TITLE
really rely on config file for field extraction order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-*.pyc
+*.py[co]
 build
 dist
 MANIFEST
+.idea/
+*.iml

--- a/mutt_ldap.py
+++ b/mutt_ldap.py
@@ -392,7 +392,10 @@ if __name__ == '__main__':
 
     connection_class = CONFIG.get_connection_class()
     attr_lst = CONFIG.get('query', 'search-fields').split(' ')[0:2]
-    optional_column = CONFIG.get('results', 'optional_column', '')
+    optional_column = ''
+    if CONFIG.has_section('results') and \
+        CONFIG.has_option('results', 'optional_column'):
+        optional_column = CONFIG.get('results', 'optional_column')
     attr_lst.append(optional_column)
     addresses = []
     with connection_class() as connection:

--- a/mutt_ldap.py
+++ b/mutt_ldap.py
@@ -352,10 +352,13 @@ def _decode_query_data(obj):
 def format_columns(address, data, attr_lst):
     yield _decode_query_data(address)
     fullname, opt_fullname, optional_column = attr_lst
-    yield _decode_query_data(data.get(fullname, data[opt_fullname])[-1])
+    LOG.debug("fullname: {fullname}; optional: {opt_fullname}; optional_column: {optional_column}".format(**locals()))
+    LOG.debug("data: {data}".format(**locals()))
+
+    yield _decode_query_data(data.get(fullname, data.get(opt_fullname))[-1])
 
     if optional_column in data:
-        yield _decode_query_data(data[optional_column][-1])
+        yield _decode_query_data(data.get(optional_column)[-1])
 
 
 def format_entry(entry, attr_lst=None):


### PR DESCRIPTION
hi, my org has cn full with name, and displayName has only 1st name.
this patch allows me to add this to my config file:

```
[query]
search-fields = cn displayName uid mail
```

and have the script fetch the data properly
before this, the order of the field was hard-coded, and one had to edit the script to get it done.
Also, I've changed a wee bit the way parse_args works, so it can be tested laters (if my hands itch...)
